### PR TITLE
Update MAPINFO.common.doom1.prt

### DIFF
--- a/installer/common/MAPINFO.common.doom1.prt
+++ b/installer/common/MAPINFO.common.doom1.prt
@@ -47,6 +47,13 @@ episode e4m1
 	optional
 }
 
+episode e5m1
+{
+	name = "$HUSTR_EPI5"  //SIGIL by John Romero
+	key = "s"
+	picname = "M_EPI5"
+}
+
 episode map01
 {
 	name = "Hell On Earth"


### PR DESCRIPTION
small change to properly place SIGIL in its correct spot, not to be confused with full SIGIL support yet, so it might look weird with two instances of SIGIL without editing SIGILs MAPINFO file